### PR TITLE
Test matrix after full assembly

### DIFF
--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -240,56 +240,60 @@ namespace aspect
                                            " = " + Utilities::to_string(eta)));
                       }
                 }
+            }
+        }
+
 #if DEBUG
-              // regardless of whether we do or do not add the Newton
-              // linearization terms, we ought to test whether the top-left
-              // block of the matrix is Symmetric Positive Definite (SPD).
-              //
-              // the reason why this is not entirely obvious is described in
-              // the paper that discusses the Newton implementation
+      if (assemble_newton_stokes_matrix)
+        {
+          // regardless of whether we do or do not add the Newton
+          // linearization terms, we ought to test whether the top-left
+          // block of the matrix is Symmetric Positive Definite (SPD).
+          //
+          // the reason why this is not entirely obvious is described in
+          // the paper that discusses the Newton implementation
+          {
+            bool testing = true;
+            for (unsigned int sample = 0; sample < 10; ++sample)
               {
-                bool testing = true;
-                for (unsigned int sample = 0; sample < 10; ++sample)
+                Vector<double> tmp (stokes_dofs_per_cell);
+
+                for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                  if (scratch.finite_element_values.get_fe().system_to_component_index(i).first < dim)
+                    tmp[i] = Utilities::generate_normal_random_number (0, 1);
+
+                const double abc =  data.local_matrix.matrix_norm_square(tmp)/(tmp*tmp);
+                if (abc < -1e-12*data.local_matrix.frobenius_norm())
                   {
-                    Vector<double> tmp (stokes_dofs_per_cell);
+                    testing = false;
+                    std::cout << sample << " Not SPD: " << abc << "; " << std::endl;
 
                     for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
-                      if (scratch.finite_element_values.get_fe().system_to_component_index(i).first < dim)
-                        tmp[i] = Utilities::generate_normal_random_number (0, 1);
-
-                    const double abc =  data.local_matrix.matrix_norm_square(tmp)/(tmp*tmp);
-                    if (abc < -1e-12*data.local_matrix.frobenius_norm())
                       {
-                        testing = false;
-                        std::cout << sample << " Not SPD: " << abc << "; " << std::endl;
+                        for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                          std::cout << std::setprecision(1)  << data.local_matrix(i,j) << "," << std::flush;
+                        std::cout << "},{" << std::endl;
+                      }
+                    std::cout << std::endl;
+                    std::cout << std::setprecision(6) << std::endl;
 
-                        for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                    Assert(testing,ExcMessage ("Error: Assembly not SPD!."));
+
+                    // Testing whether all entries are finite.
+                    for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                      {
+                        for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
-                            for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
-                              std::cout << std::setprecision(1)  << data.local_matrix(i,j) << "," << std::flush;
-                            std::cout << "},{" << std::endl;
-                          }
-                        std::cout << std::endl;
-                        std::cout << std::setprecision(6) << std::endl;
-
-                        Assert(testing,ExcMessage ("Error: Assembly not SPD!."));
-
-                        // Testing whether all entries are finite.
-                        for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
-                          {
-                            for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
-                              {
-                                Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),ExcMessage ("Error: Assembly matrix is not finite."));
-                              }
+                            Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),ExcMessage ("Error: Assembly matrix is not finite."));
                           }
                       }
                   }
-                if (testing == false)
-                  std::cout << std::endl;
               }
-#endif
-            }
+            if (testing == false)
+              std::cout << std::endl;
+          }
         }
+#endif
     }
 
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -153,6 +153,12 @@ namespace aspect
                   scratch.grads_phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(i,q);
                   scratch.div_phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (i, q);
 
+#if debug
+                  // This is needed to test the velocity part of the matrix for
+                  // being symmetric positive-definite.
+                  scratch.dof_component_indices[i_stokes] = fe.system_to_component_index(i).first;
+#endif
+
                   ++i_stokes;
                 }
               ++i;
@@ -254,12 +260,13 @@ namespace aspect
           // the paper that discusses the Newton implementation
           {
             bool testing = true;
+
             for (unsigned int sample = 0; sample < 10; ++sample)
               {
                 Vector<double> tmp (stokes_dofs_per_cell);
 
                 for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
-                  if (scratch.finite_element_values.get_fe().system_to_component_index(i).first < dim)
+                  if (scratch.dof_component_indices[i] < dim)
                     tmp[i] = Utilities::generate_normal_random_number (0, 1);
 
                 const double abc =  data.local_matrix.matrix_norm_square(tmp)/(tmp*tmp);


### PR DESCRIPTION
Hi Menno,
I think I found your testing problem. You tested the matrix for SPD after the contribution of every single quadrature point. Does it not make more sense to test the fully assembled matrix? The reason I think that is more reasonable is that your test model failed during a stage when the derivative scaling factor was 0, i.e. *without the Newton derivatives*. The included changes move the test out of the loop over all quadrature points and only tests the matrix after the full assembly of all contributions. This way the model you posted passes the test.